### PR TITLE
Small update to woocommerce-display-order-count

### DIFF
--- a/woocommerce-display-order-count.php
+++ b/woocommerce-display-order-count.php
@@ -50,12 +50,10 @@ function display_woocommerce_order_count( $atts, $content = null ) {
 
 		// if we didn't get a wc- prefix, add one
 		if ( 0 !== strpos( $status, 'wc-' ) ) {
-			$status = str_replace( $status, 'wc-' . $status, $status );
+			$status = 'wc-' . $status;
 		}
 
-		$total_orders = wp_count_posts( 'shop_order' )->$status;
-
-		$order_count += $total_orders;
+		$order_count += wp_count_posts( 'shop_order' )->$status;
 	}
 
 	ob_start();


### PR DESCRIPTION
2 things: 
1) There is no need to do a str_replace in this situation. Although the native php function is very fast, in this situation you are already passing the the correct concatenated string into str_replace and it takes longer than it needs to. Not only is it more readable this way, but its faster. I benchmarked speed of just concatenating vs using str_replace at 1,000,000 elements and the time dropped from 4.6 seconds to 1.2.

2) The variable total_orders appears to be a misnomer, and doesn't appear to be necessary.